### PR TITLE
Fix consultant dashboard test data and headings

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,9 @@ Ensure all new panels use `country_id` and `flag_emoji` for dynamic configuratio
 - The `normalizeCountrySlug` function ensures routes resolve to either `georgia` or `global`.
 - Netlify uses the `_redirects` file to serve SPA routes for deep links.
 - Incrementing the `CACHE_NAME` in `public/sw.js` invalidates old service workers. Users may need to hard-refresh after deployment.
+
+## Supabase Data Integrity
+
+- Georgia's country record must use the slug `georgia`; legacy `ge` values should be avoided.
+- Consultant dashboards rely on the `consultant_country_assignments` and `applications` tables to link consultants, countries and clients.
+- Run periodic checks or migrations to ensure no `ge` slugs remain in the database.

--- a/src/components/consultant/accounting/ProductionAccountingModule.tsx
+++ b/src/components/consultant/accounting/ProductionAccountingModule.tsx
@@ -44,6 +44,7 @@ import {
 
 interface ProductionAccountingModuleProps {
   consultantId: string;
+  countryId: number;
 }
 
 interface ClientData {
@@ -69,7 +70,7 @@ interface AccountingData {
   consultant_notes: any[];
 }
 
-const ProductionAccountingModule: React.FC<ProductionAccountingModuleProps> = ({ consultantId }) => {
+const ProductionAccountingModule: React.FC<ProductionAccountingModuleProps> = ({ consultantId, countryId }) => {
   // State Management
   const [clients, setClients] = useState<ClientData[]>([]);
   const [selectedClient, setSelectedClient] = useState<ClientData | null>(null);
@@ -171,7 +172,7 @@ const ProductionAccountingModule: React.FC<ProductionAccountingModuleProps> = ({
   useEffect(() => {
     loadClients();
     loadConsultantLanguage();
-  }, [consultantId]);
+  }, [consultantId, countryId]);
 
   // Load accounting data when client is selected
   useEffect(() => {
@@ -203,8 +204,8 @@ const ProductionAccountingModule: React.FC<ProductionAccountingModuleProps> = ({
       console.log('🔍 [ACCOUNTING] Loading clients...');
       
       const clientsData = await ClientDataManager.fetchConsultantClients({
-        consultantEmail: 'georgia_consultant@consulting19.com',
-        countryId: 1,
+        consultantId,
+        countryId,
         search: searchTerm,
         limit: 100,
         offset: 0

--- a/src/components/consultant/messaging/ConsultantMessagingModule.tsx
+++ b/src/components/consultant/messaging/ConsultantMessagingModule.tsx
@@ -6,7 +6,6 @@ import { useMessageTranslation } from '../../../hooks/useMessageTranslation';
 import TranslatedMessage from '../../shared/TranslatedMessage';
 import MessageComposer from '../../shared/MessageComposer';
 import LanguageSelector from '../../shared/LanguageSelector';
-import { fetchClients } from '../dashboard/CountryBasedClients.tsx';
 import ClientDataManager from '../../../lib/clientDataManager';
 import { 
   MessageSquare, 
@@ -27,9 +26,10 @@ import {
 
 interface ConsultantMessagingModuleProps {
   consultantId: string;
+  countryId?: number;
 }
 
-const ConsultantMessagingModule: React.FC<ConsultantMessagingModuleProps> = ({ consultantId }) => {
+const ConsultantMessagingModule: React.FC<ConsultantMessagingModuleProps> = ({ consultantId, countryId }) => {
   const [consultant, setConsultant] = useState<any>(null);
   const [clients, setClients] = useState<any[]>([]);
   const [messages, setMessages] = useState<any[]>([]);
@@ -45,7 +45,7 @@ const ConsultantMessagingModule: React.FC<ConsultantMessagingModuleProps> = ({ c
   useEffect(() => {
     loadConsultantData();
     loadClients();
-  }, [consultantId]);
+  }, [consultantId, countryId]);
 
   useEffect(() => {
     if (selectedClient) {
@@ -77,8 +77,8 @@ const ConsultantMessagingModule: React.FC<ConsultantMessagingModuleProps> = ({ c
     try {
       console.log('🔍 Loading clients for messaging...');
       const clientsData = await ClientDataManager.fetchConsultantClients({
-        consultantEmail: 'georgia_consultant@consulting19.com',
-        countryId: 1,
+        consultantId,
+        countryId: countryId ?? 0,
         search: '',
         limit: 50,
         offset: 0

--- a/src/pages/ConsultantDashboard.tsx
+++ b/src/pages/ConsultantDashboard.tsx
@@ -46,6 +46,8 @@ const ConsultantDashboard: React.FC<ConsultantDashboardProps> = ({ country = 'gl
   const slug = normalizeCountrySlug(country);
   const basePath = slug === 'global' ? '/consultant-dashboard' : `/${slug}/consultant-dashboard`;
 
+  const countryId = assignedCountry?.id || consultant?.countries?.id || 0;
+
   useEffect(() => {
     const checkAuth = async () => {
       try {
@@ -158,12 +160,6 @@ const ConsultantDashboard: React.FC<ConsultantDashboardProps> = ({ country = 'gl
       case 'performance':
         return (
           <div className="space-y-8">
-            <div className="mb-8">
-              <h2 className="text-3xl font-bold text-gray-900 mb-2">Performans Merkezi</h2>
-              <p className="text-gray-600">
-                Müşterilerinizi yönetin, gelir takibi yapın ve danışmanlık işinizi büyütün
-              </p>
-            </div>
             <PerformanceHub consultantId={consultant.id} />
             <QuickActions consultantId={consultant.id} />
           </div>
@@ -172,38 +168,20 @@ const ConsultantDashboard: React.FC<ConsultantDashboardProps> = ({ country = 'gl
       case 'messages':
         return (
           <div className="space-y-8">
-            <div className="mb-8">
-              <h2 className="text-3xl font-bold text-gray-900 mb-2">Müşteri Mesajları</h2>
-              <p className="text-gray-600">
-                Müşterilerinizle iletişim kurun ve mesajları yönetin
-              </p>
-            </div>
-            <ConsultantMessagingModule consultantId={consultant.id} />
+            <ConsultantMessagingModule consultantId={consultant.id} countryId={countryId} />
           </div>
         );
         
       case 'accounting':
         return (
           <div className="space-y-8">
-            <div className="mb-8">
-              <h2 className="text-3xl font-bold text-gray-900 mb-2">Muhasebe Yönetimi</h2>
-              <p className="text-gray-600">
-                Müşteri belgelerini yönetin, ödeme takibi yapın ve mali raporlar oluşturun
-              </p>
-            </div>
-            <ProductionAccountingModule consultantId={consultant.id} />
+            <ProductionAccountingModule consultantId={consultant.id} countryId={countryId} />
           </div>
         );
         
       case 'custom-services':
         return (
           <div className="space-y-8">
-            <div className="mb-8">
-              <h2 className="text-3xl font-bold text-gray-900 mb-2">Özel Hizmetlerim</h2>
-              <p className="text-gray-600">
-                Kendi hizmetlerinizi oluşturun ve müşterilerinize önerin
-              </p>
-            </div>
             <CustomServiceManager consultantId={consultant.id} />
           </div>
         );
@@ -211,25 +189,13 @@ const ConsultantDashboard: React.FC<ConsultantDashboardProps> = ({ country = 'gl
       case 'country-clients':
         return (
           <div className="space-y-8">
-            <div className="mb-8">
-              <h2 className="text-3xl font-bold text-gray-900 mb-2">Ülke Müşterileri</h2>
-              <p className="text-gray-600">
-                Ülke bazlı müşteri yönetimi ve CRM sistemi
-              </p>
-            </div>
-            <CountryBasedClients consultantId={consultant.id} />
+            <CountryBasedClients consultantId={consultant.id} countryId={countryId} />
           </div>
         );
         
       case 'legacy-orders':
         return (
           <div className="space-y-8">
-            <div className="mb-8">
-              <h2 className="text-3xl font-bold text-gray-900 mb-2">Legacy Sipariş Yönetimi</h2>
-              <p className="text-gray-600">
-                Eski sistemden gelen siparişleri yönetin ve komisyonları takip edin
-              </p>
-            </div>
             <LegacyOrderManager consultantId={consultant.id} />
           </div>
         );
@@ -237,12 +203,6 @@ const ConsultantDashboard: React.FC<ConsultantDashboardProps> = ({ country = 'gl
       case 'admin-messages':
         return (
           <div className="space-y-8">
-            <div className="mb-8">
-              <h2 className="text-3xl font-bold text-gray-900 mb-2">Admin İletişimi</h2>
-              <p className="text-gray-600">
-                Sistem yöneticileri ile iletişim kurun ve bildirimleri görüntüleyin
-              </p>
-            </div>
             <ConsultantToAdminMessaging consultantId={consultant.id} />
           </div>
         );
@@ -250,12 +210,6 @@ const ConsultantDashboard: React.FC<ConsultantDashboardProps> = ({ country = 'gl
       case 'country-content':
         return (
           <div className="space-y-8">
-            <div className="mb-8">
-              <h2 className="text-3xl font-bold text-gray-900 mb-2">Ülke İçerik Yönetimi</h2>
-              <p className="text-gray-600">
-                Atandığınız ülkelerin frontend içeriğini yönetin
-              </p>
-            </div>
             <CountryContentManager consultantId={consultant.id} />
           </div>
         );
@@ -263,12 +217,6 @@ const ConsultantDashboard: React.FC<ConsultantDashboardProps> = ({ country = 'gl
       default:
         return (
           <div className="space-y-8">
-            <div className="mb-8">
-              <h2 className="text-3xl font-bold text-gray-900 mb-2">Performans Merkezi</h2>
-              <p className="text-gray-600">
-                Müşterilerinizi yönetin, gelir takibi yapın ve danışmanlık işinizi büyütün
-              </p>
-            </div>
             <PerformanceHub consultantId={consultant.id} />
             <QuickActions consultantId={consultant.id} />
           </div>


### PR DESCRIPTION
## Summary
- remove duplicate dashboard headings and delegate titles to child modules
- parameterize consultant client lookups with consultant and country IDs
- document Supabase slug normalization and data integrity

## Testing
- `pnpm i` *(fails: ERR_PNPM_FETCH_403 Forbidden)*
- `pnpm build` *(fails: vite: not found)*
- `npx serve -s dist` *(fails: 403 Forbidden from registry)*
- `curl -I http://localhost:3000/consultant-dashboard/performance` *(connection refused)*
- `curl -I http://localhost:3000/georgia/consultant-dashboard/performance` *(connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68976aa869788332bf5785de880dd545