### PR TITLE
Use env-driven Supabase URLs

### DIFF
--- a/src/components/client/accounting/EnhancedAccountingModule.tsx
+++ b/src/components/client/accounting/EnhancedAccountingModule.tsx
@@ -107,23 +107,13 @@ const EnhancedAccountingModule: React.FC<EnhancedAccountingModuleProps> = ({ cli
       setLoading(true);
       console.log('🔍 [CLIENT-ACCOUNTING] Loading data for client:', clientId);
       
-      const apiUrl = `${import.meta.env.VITE_SUPABASE_URL}/functions/v1/accounting-data`;
-      
-      const response = await fetch(apiUrl, {
-        method: 'POST',
-        headers: {
-          'Authorization': `Bearer ${import.meta.env.VITE_SUPABASE_ANON_KEY}`,
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({
-          client_id: clientId
-        })
+      const { data, error } = await supabase.functions.invoke('accounting-data', {
+        body: { client_id: clientId }
       });
 
-      if (response.ok) {
-        const result = await response.json();
-        console.log('✅ [CLIENT-ACCOUNTING] Data loaded:', result.data);
-        setAccountingData(result.data || {
+      if (!error && data?.data) {
+        console.log('✅ [CLIENT-ACCOUNTING] Data loaded:', data.data);
+        setAccountingData(data.data || {
           documents: [],
           payments: [],
           messages: [],
@@ -330,15 +320,8 @@ const EnhancedAccountingModule: React.FC<EnhancedAccountingModuleProps> = ({ cli
         .getPublicUrl(filePath);
 
       // Create document record
-      const apiUrl = `${import.meta.env.VITE_SUPABASE_URL}/functions/v1/accounting-actions`;
-      
-      const response = await fetch(apiUrl, {
-        method: 'POST',
-        headers: {
-          'Authorization': `Bearer ${import.meta.env.VITE_SUPABASE_ANON_KEY}`,
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({
+      const { error: actionError } = await supabase.functions.invoke('accounting-actions', {
+        body: {
           action: 'upload_document',
           payload: {
             client_id: clientId,
@@ -350,10 +333,10 @@ const EnhancedAccountingModule: React.FC<EnhancedAccountingModuleProps> = ({ cli
             description: uploadForm.description,
             consultant_id: 'c3d4e5f6-a7b8-4012-8456-789012cdefab' // Nino's ID for notification
           }
-        })
+        }
       });
 
-      if (!response.ok) throw new Error('Document upload failed');
+      if (actionError) throw new Error('Document upload failed');
 
       // Reset form and reload
       setUploadForm({
@@ -375,15 +358,8 @@ const EnhancedAccountingModule: React.FC<EnhancedAccountingModuleProps> = ({ cli
     e.preventDefault();
     
     try {
-      const apiUrl = `${import.meta.env.VITE_SUPABASE_URL}/functions/v1/accounting-actions`;
-      
-      const response = await fetch(apiUrl, {
-        method: 'POST',
-        headers: {
-          'Authorization': `Bearer ${import.meta.env.VITE_SUPABASE_ANON_KEY}`,
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({
+      const { error } = await supabase.functions.invoke('accounting-actions', {
+        body: {
           action: 'send_accounting_message',
           payload: {
             sender_id: clientId,
@@ -392,10 +368,10 @@ const EnhancedAccountingModule: React.FC<EnhancedAccountingModuleProps> = ({ cli
             original_language: userLanguage,
             message_type: 'accounting'
           }
-        })
+        }
       });
 
-      if (!response.ok) throw new Error('Message send failed');
+      if (error) throw new Error('Message send failed');
 
       setMessageForm({
         subject: '',
@@ -1020,15 +996,8 @@ const EnhancedAccountingModule: React.FC<EnhancedAccountingModuleProps> = ({ cli
               <h4 className="text-lg font-semibold text-gray-900 mb-4">Danışmanınıza Mesaj Gönder</h4>
               <MessageComposer
                 onSendMessage={async (msg, lang) => {
-                  const apiUrl = `${import.meta.env.VITE_SUPABASE_URL}/functions/v1/accounting-actions`;
-                  
-                  const response = await fetch(apiUrl, {
-                    method: 'POST',
-                    headers: {
-                      'Authorization': `Bearer ${import.meta.env.VITE_SUPABASE_ANON_KEY}`,
-                      'Content-Type': 'application/json',
-                    },
-                    body: JSON.stringify({
+                  const { error } = await supabase.functions.invoke('accounting-actions', {
+                    body: {
                       action: 'send_accounting_message',
                       payload: {
                         sender_id: clientId,
@@ -1037,10 +1006,10 @@ const EnhancedAccountingModule: React.FC<EnhancedAccountingModuleProps> = ({ cli
                         original_language: lang,
                         message_type: 'accounting'
                       }
-                    })
+                    }
                   });
 
-                  if (!response.ok) throw new Error('Message send failed');
+                  if (error) throw new Error('Message send failed');
                   loadAccountingData();
                 }}
                 userLanguage={userLanguage}

--- a/src/components/consultant/accounting/ProductionAccountingModule.tsx
+++ b/src/components/consultant/accounting/ProductionAccountingModule.tsx
@@ -518,15 +518,8 @@ const ProductionAccountingModule: React.FC<ProductionAccountingModuleProps> = ({
     if (!selectedClient) return;
 
     try {
-      const apiUrl = `${import.meta.env.VITE_SUPABASE_URL}/functions/v1/accounting-actions`;
-      
-      const response = await fetch(apiUrl, {
-        method: 'POST',
-        headers: {
-          'Authorization': `Bearer ${import.meta.env.VITE_SUPABASE_ANON_KEY}`,
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({
+      const { error } = await supabase.functions.invoke('accounting-actions', {
+        body: {
           action: 'request_document',
           payload: {
             client_id: selectedClient.client_id,
@@ -535,10 +528,10 @@ const ProductionAccountingModule: React.FC<ProductionAccountingModuleProps> = ({
             message: documentRequestForm.message,
             priority: documentRequestForm.priority
           }
-        })
+        }
       });
 
-      if (!response.ok) throw new Error('Document request failed');
+      if (error) throw new Error('Document request failed');
 
       setDocumentRequestForm({
         title: '',
@@ -562,15 +555,8 @@ const ProductionAccountingModule: React.FC<ProductionAccountingModuleProps> = ({
     if (!selectedClient) return;
 
     try {
-      const apiUrl = `${import.meta.env.VITE_SUPABASE_URL}/functions/v1/accounting-actions`;
-      
-      const response = await fetch(apiUrl, {
-        method: 'POST',
-        headers: {
-          'Authorization': `Bearer ${import.meta.env.VITE_SUPABASE_ANON_KEY}`,
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({
+      const { error } = await supabase.functions.invoke('accounting-actions', {
+        body: {
           action: 'create_payment_schedule',
           payload: {
             client_id: selectedClient.client_id,
@@ -584,10 +570,10 @@ const ProductionAccountingModule: React.FC<ProductionAccountingModuleProps> = ({
             recurring_interval: paymentForm.recurring ? paymentForm.recurring_interval : null,
             country_id: 1 // Georgia
           }
-        })
+        }
       });
 
-      if (!response.ok) throw new Error('Payment creation failed');
+      if (error) throw new Error('Payment creation failed');
 
       setPaymentForm({
         payment_type: 'accounting_fee',
@@ -610,25 +596,18 @@ const ProductionAccountingModule: React.FC<ProductionAccountingModuleProps> = ({
 
   const handleDocumentAction = async (documentId: string, action: string, notes?: string) => {
     try {
-      const apiUrl = `${import.meta.env.VITE_SUPABASE_URL}/functions/v1/accounting-actions`;
-      
-      const response = await fetch(apiUrl, {
-        method: 'POST',
-        headers: {
-          'Authorization': `Bearer ${import.meta.env.VITE_SUPABASE_ANON_KEY}`,
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({
+      const { error } = await supabase.functions.invoke('accounting-actions', {
+        body: {
           action: 'update_document_status',
           payload: {
             document_id: documentId,
             status: action,
             notes: notes || null
           }
-        })
+        }
       });
 
-      if (!response.ok) throw new Error('Document update failed');
+      if (error) throw new Error('Document update failed');
 
       loadAccountingData();
       alert(`✅ Belge ${getStatusLabel(action).toLowerCase()}!`);
@@ -643,15 +622,8 @@ const ProductionAccountingModule: React.FC<ProductionAccountingModuleProps> = ({
     if (!selectedClient) return;
 
     try {
-      const apiUrl = `${import.meta.env.VITE_SUPABASE_URL}/functions/v1/accounting-actions`;
-      
-      const response = await fetch(apiUrl, {
-        method: 'POST',
-        headers: {
-          'Authorization': `Bearer ${import.meta.env.VITE_SUPABASE_ANON_KEY}`,
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({
+      const { error } = await supabase.functions.invoke('accounting-actions', {
+        body: {
           action: 'add_consultant_note',
           payload: {
             consultant_id: consultantId,
@@ -660,10 +632,10 @@ const ProductionAccountingModule: React.FC<ProductionAccountingModuleProps> = ({
             note_content: noteForm.note_content,
             reference_id: noteForm.reference_id
           }
-        })
+        }
       });
 
-      if (!response.ok) throw new Error('Note creation failed');
+      if (error) throw new Error('Note creation failed');
 
       setNoteForm({
         note_type: 'general',
@@ -1322,15 +1294,8 @@ const ProductionAccountingModule: React.FC<ProductionAccountingModuleProps> = ({
 
                   <MessageComposer
                     onSendMessage={async (msg, lang) => {
-                      const apiUrl = `${import.meta.env.VITE_SUPABASE_URL}/functions/v1/accounting-actions`;
-                      
-                      const response = await fetch(apiUrl, {
-                        method: 'POST',
-                        headers: {
-                          'Authorization': `Bearer ${import.meta.env.VITE_SUPABASE_ANON_KEY}`,
-                          'Content-Type': 'application/json',
-                        },
-                        body: JSON.stringify({
+                      const { error } = await supabase.functions.invoke('accounting-actions', {
+                        body: {
                           action: 'send_accounting_message',
                           payload: {
                             sender_id: consultantId,
@@ -1339,10 +1304,10 @@ const ProductionAccountingModule: React.FC<ProductionAccountingModuleProps> = ({
                             original_language: lang,
                             message_type: 'accounting'
                           }
-                        })
+                        }
                       });
 
-                      if (!response.ok) throw new Error('Message send failed');
+                      if (error) throw new Error('Message send failed');
                       loadAccountingData();
                     }}
                     userLanguage={consultantLanguage}

--- a/src/components/consultant/dashboard/CountryBasedClients.tsx
+++ b/src/components/consultant/dashboard/CountryBasedClients.tsx
@@ -290,20 +290,15 @@ const CountryBasedClients: React.FC<CountryBasedClientsProps> = ({ consultantId,
         <div className="mt-4 bg-black/40 p-4 rounded-xl">
           <h4 className="text-white font-bold mb-2">🧪 Manual API Test (Copy to Browser Console):</h4>
           <div className="bg-black/60 p-3 rounded text-green-300 text-xs font-mono">
-            {`fetch('${import.meta.env.VITE_SUPABASE_URL}/functions/v1/consultant-clients', {
-  method: 'POST',
-  headers: {
-    'Authorization': 'Bearer ${import.meta.env.VITE_SUPABASE_ANON_KEY}',
-    'Content-Type': 'application/json'
-  },
-  body: JSON.stringify({
+            {`await supabase.functions.invoke('consultant-clients', {
+  body: {
     consultantId: 'CONSULTANT_ID',
     countryId: COUNTRY_ID
-  })
-}).then(r => r.json()).then(console.log).catch(console.error);`}
+  }
+}).then(({ data }) => console.log(data)).catch(console.error);`}
           </div>
           <p className="text-white/70 text-xs mt-2">
-            Expected: {`{ ok: true, data: [{ email: 'ahmet@test.com', ... }] }`}
+            Expected: {`{ data: [{ email: 'ahmet@test.com', ... }] }`}
           </p>
         </div>
       </div>

--- a/src/lib/supabaseClient.ts
+++ b/src/lib/supabaseClient.ts
@@ -1,25 +1,18 @@
 import { createClient } from '@supabase/supabase-js';
 
 const url = import.meta.env.VITE_SUPABASE_URL;
-const anonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
-const functionsUrl = import.meta.env.VITE_SUPABASE_FUNCTIONS_URL ?? url;
+const key = import.meta.env.VITE_SUPABASE_ANON_KEY;
+const fUrl = import.meta.env.VITE_SUPABASE_FUNCTIONS_URL ?? url;
 
-if (!url || !anonKey) {
-  // Visible once after boot/login – helps debug Netlify env
-  // Do NOT throw; app should still render a friendly error elsewhere.
-  console.error('❌ Missing Supabase env', {
-    urlPresent: !!url,
-    anonKeyPresent: !!anonKey,
-  });
+console.info('[VITE_SUPABASE_URL]', import.meta.env.VITE_SUPABASE_URL);
+console.info(
+  '[VITE_SUPABASE_FUNCTIONS_URL]',
+  import.meta.env.VITE_SUPABASE_FUNCTIONS_URL ?? '(same)'
+);
+console.info('[VITE_SUPABASE_KEY?]', !!import.meta.env.VITE_SUPABASE_ANON_KEY);
+
+export const supabase = createClient(url!, key!, { functions: { url: fUrl } });
+
+if (typeof window !== 'undefined') {
+  (window as any).supabase = supabase;
 }
-
-console.info('[Supabase config]', {
-  url: import.meta.env.VITE_SUPABASE_URL,
-  functionsUrl: import.meta.env.VITE_SUPABASE_FUNCTIONS_URL ?? '(same as url)',
-  anonKeyPresent: !!import.meta.env.VITE_SUPABASE_ANON_KEY,
-});
-
-export const supabase = createClient(url!, anonKey!, {
-  // Ensure edge functions use the correct base domain
-  functions: { url: functionsUrl },
-});


### PR DESCRIPTION
## Summary
- enforce env-based Supabase client with runtime logging
- replace hard-coded function URLs with `supabase.functions.invoke`
- update dashboards and modules to call Supabase via env-configured client

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68978dc1d6b8833281cdfc075f66c1a1