### PR TITLE
fix: normalize Supabase URLs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,7 @@
 VITE_SUPABASE_URL=your-supabase-project-url
 VITE_SUPABASE_ANON_KEY=your-supabase-anon-key
 VITE_SUPABASE_SERVICE_ROLE_KEY=your-supabase-service-role-key
+VITE_SUPABASE_FUNCTIONS_URL=your-supabase-project-url/functions/v1
 
 # aiagent19.com Integration
 VITE_AI_AGENT_URL=https://aiagent19.com/api

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Set the following variables for deployments (e.g., Netlify → Site settings →
 ```
 VITE_SUPABASE_URL = https://<project-ref>.supabase.co
 VITE_SUPABASE_ANON_KEY = <anon_jwt>
-VITE_SUPABASE_FUNCTIONS_URL = https://<project-ref>.functions.supabase.co (optional; defaults to URL)
+VITE_SUPABASE_FUNCTIONS_URL = https://<project-ref>.supabase.co/functions/v1 (optional; defaults to URL)
 ```
 
 After setting these, redeploy the site so Vite injects them into the bundle.

--- a/src/lib/checkSupabase.ts
+++ b/src/lib/checkSupabase.ts
@@ -1,11 +1,13 @@
 export async function checkSupabaseConnectivity() {
-  const url = import.meta.env.VITE_SUPABASE_URL;
+  const baseUrl = import.meta.env.VITE_SUPABASE_URL?.replace(/\/+$/, '');
   const key = import.meta.env.VITE_SUPABASE_ANON_KEY;
-  const functionsBase = import.meta.env.VITE_SUPABASE_FUNCTIONS_URL ?? url;
+  const functionsUrl =
+    import.meta.env.VITE_SUPABASE_FUNCTIONS_URL?.replace(/\/+$/, '') ||
+    (baseUrl ? `${baseUrl}/functions/v1` : undefined);
 
   console.info('[Supabase env]', {
-    url,
-    functionsUrl: functionsBase,
+    url: baseUrl,
+    functionsUrl,
     anonKeyLength: key ? key.length : 0,
   });
 
@@ -15,8 +17,8 @@ export async function checkSupabaseConnectivity() {
     headers['Authorization'] = `Bearer ${key}`;
   }
 
-  const restUrl = url ? `${url}/rest/v1/` : '';
-  const fnUrl = functionsBase ? `${functionsBase}/functions/v1/` : '';
+  const restUrl = baseUrl ? `${baseUrl}/rest/v1/` : '';
+  const fnUrl = functionsUrl || '';
 
   let restReachable = false;
   let functionsReachable = false;

--- a/src/lib/supabaseClient.ts
+++ b/src/lib/supabaseClient.ts
@@ -1,17 +1,15 @@
 import { createClient } from '@supabase/supabase-js';
 
-const url = import.meta.env.VITE_SUPABASE_URL;
-const key = import.meta.env.VITE_SUPABASE_ANON_KEY;
-const fUrl = import.meta.env.VITE_SUPABASE_FUNCTIONS_URL ?? url;
+const baseUrl = import.meta.env.VITE_SUPABASE_URL?.replace(/\/+$/, '');
+const functionsUrl =
+  import.meta.env.VITE_SUPABASE_FUNCTIONS_URL?.replace(/\/+$/, '') ||
+  (baseUrl ? `${baseUrl}/functions/v1` : undefined);
 
-console.info('[VITE_SUPABASE_URL]', import.meta.env.VITE_SUPABASE_URL);
-console.info(
-  '[VITE_SUPABASE_FUNCTIONS_URL]',
-  import.meta.env.VITE_SUPABASE_FUNCTIONS_URL ?? '(same)'
+export const supabase = createClient(
+  baseUrl!,
+  import.meta.env.VITE_SUPABASE_ANON_KEY!,
+  functionsUrl ? { functions: { url: functionsUrl } } : undefined
 );
-console.info('[VITE_SUPABASE_KEY?]', !!import.meta.env.VITE_SUPABASE_ANON_KEY);
-
-export const supabase = createClient(url!, key!, { functions: { url: fUrl } });
 
 if (typeof window !== 'undefined') {
   (window as any).supabase = supabase;


### PR DESCRIPTION
## Summary
- normalize Supabase client initialization to derive functions URL from base
- add VITE_SUPABASE_FUNCTIONS_URL to `.env.example` and docs
- ensure Supabase connectivity checker uses normalized URLs

## Testing
- `npm run build`
- `curl -i "https://xxxxx.supabase.co/rest/v1/consultant_country_assignments?select=*&consultant_id=eq.test&status=eq.true" -H "apikey: x" -H "Authorization: Bearer x"` *(fails: CONNECT tunnel failed, response 403)*
- `curl -i "https://xxxxx.supabase.co/functions/v1/consultant-clients" -H "Authorization: Bearer x" -H "Content-Type: application/json" --data '{}'` *(fails: CONNECT tunnel failed, response 403)*
- `supabase functions deploy consultant-clients` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6897a93689cc8332960a3a782a044ca7