### PR TITLE
fix: correct Supabase env and client init

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,8 @@
 # Supabase Configuration
-VITE_SUPABASE_URL=your-supabase-project-url
-VITE_SUPABASE_ANON_KEY=your-supabase-anon-key
+VITE_SUPABASE_URL=https://fwgaekupwecsruxjebb.supabase.co
+VITE_SUPABASE_ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImZ3Z2Fla3Vwd2Vjc3J1eGplYmJkIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTM4OTQyNjEsImV4cCI6MjA2OTQ3MDI2MX0.HzssNASnDherzWBjEmoNtrsmqDRW03-bzSbN1w7xYEY
 VITE_SUPABASE_SERVICE_ROLE_KEY=your-supabase-service-role-key
-VITE_SUPABASE_FUNCTIONS_URL=your-supabase-project-url/functions/v1
+VITE_SUPABASE_FUNCTIONS_URL=https://fwgaekupwecsruxjebb.supabase.co/functions/v1
 
 # aiagent19.com Integration
 VITE_AI_AGENT_URL=https://aiagent19.com/api

--- a/src/lib/supabaseClient.ts
+++ b/src/lib/supabaseClient.ts
@@ -10,7 +10,3 @@ export const supabase = createClient(
   import.meta.env.VITE_SUPABASE_ANON_KEY!,
   functionsUrl ? { functions: { url: functionsUrl } } : undefined
 );
-
-if (typeof window !== 'undefined') {
-  (window as any).supabase = supabase;
-}


### PR DESCRIPTION
## Summary
- normalize Supabase environment variables
- standardize Supabase client initialization

## Testing
- `npm test` (fails: Missing script)
- `npm run build`
- `supabase functions deploy consultant-clients` (command not found)
- `curl -i --proxy "" https://fwgaekupwecsruxjebb.supabase.co/rest/v1/consultant_country_assignments?...` (Could not resolve host)
- `curl -i --proxy "" https://fwgaekupwecsruxjebb.supabase.co/functions/v1/consultant-clients --data '{}'` (Could not resolve host)


------
https://chatgpt.com/codex/tasks/task_e_6897ae2dc660833283836cd9f32763e1