### PR TITLE
Use Supabase auth in consultant dashboard and country manager

### DIFF
--- a/src/components/ProtectedRoute.jsx
+++ b/src/components/ProtectedRoute.jsx
@@ -1,17 +1,55 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { Navigate } from 'react-router-dom';
+import { supabase } from '../lib/supabaseClient';
 
 const ProtectedRoute = ({ children, requiredRole }) => {
-  const user = JSON.parse(localStorage.getItem('user') || '{}');
-  
-  if (!user.id) {
+  const [loading, setLoading] = useState(true);
+  const [userProfile, setUserProfile] = useState(null);
+
+  useEffect(() => {
+    const checkSession = async () => {
+      const {
+        data: { user }
+      } = await supabase.auth.getUser();
+
+      if (!user) {
+        setLoading(false);
+        return;
+      }
+
+      let profile = null;
+      const stored = localStorage.getItem('user');
+      if (stored) {
+        profile = JSON.parse(stored);
+      } else {
+        const { data: profileData } = await supabase
+          .from('users')
+          .select('*')
+          .eq('id', user.id)
+          .maybeSingle();
+        if (profileData) {
+          profile = profileData;
+          localStorage.setItem('user', JSON.stringify(profileData));
+        }
+      }
+
+      setUserProfile(profile);
+      setLoading(false);
+    };
+
+    checkSession();
+  }, []);
+
+  if (loading) return null;
+
+  if (!userProfile) {
     return <Navigate to="/login" replace />;
   }
-  
-  if (requiredRole && user.role !== requiredRole) {
+
+  if (requiredRole && userProfile.role !== requiredRole) {
     return <Navigate to="/unauthorized" replace />;
   }
-  
+
   return children;
 };
 

--- a/src/components/consultant/dashboard/CountryContentManager.tsx
+++ b/src/components/consultant/dashboard/CountryContentManager.tsx
@@ -81,7 +81,7 @@ const CountryContentManager: React.FC<CountryContentManagerProps> = ({ consultan
         .from('consultant_country_assignments')
         .select(`countries(id, name, flag_emoji, slug)`)
         .eq('consultant_id', consultantId)
-        .eq('status', true);
+        .or('status.eq.true,status.is.null');
 
       const countries = data?.map((a: any) => a.countries).filter(Boolean) || [];
       setAssignedCountries(countries);
@@ -455,9 +455,9 @@ const CountryContentManager: React.FC<CountryContentManagerProps> = ({ consultan
           Atandığınız Ülkeler
         </h3>
         {assignedCountries.length === 0 ? (
-          <p className="text-gray-600">
-            No countries assigned to you yet.
-          </p>
+          <div className="p-4 bg-yellow-50 border border-yellow-200 rounded-lg">
+            No countries assigned to you yet. Please contact an administrator.
+          </div>
         ) : (
           <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
             {assignedCountries.map((country) => (


### PR DESCRIPTION
## Summary
- Replace localStorage login with Supabase auth and profile lookup
- Protect routes and consultant dashboard using Supabase session checks
- Allow Country Content Manager to load assignments with null status and show empty-state notice

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6897b5952fa0833281781ca516c8b6f4