### PR TITLE
Implement Supabase login and session check

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,9 @@ All content forms include a language selector (currently `tr` and `en`). Transla
 Set the following variables for deployments (e.g., Netlify → Site settings → Build & deploy → Environment):
 
 ```
-VITE_SUPABASE_URL = https://<project-ref>.supabase.co
+VITE_SUPABASE_URL = https://fwgaekupwecsruxjebb.supabase.co
 VITE_SUPABASE_ANON_KEY = <anon_jwt>
-VITE_SUPABASE_FUNCTIONS_URL = https://<project-ref>.supabase.co/functions/v1 (optional; defaults to URL)
+VITE_SUPABASE_FUNCTIONS_URL = https://fwgaekupwecsruxjebb.supabase.co/functions/v1
 ```
 
 After setting these, redeploy the site so Vite injects them into the bundle.

--- a/src/lib/login.ts
+++ b/src/lib/login.ts
@@ -3,17 +3,5 @@ import { supabase } from '@/lib/supabaseClient';
 export async function login(email: string, password: string) {
   const { data, error } = await supabase.auth.signInWithPassword({ email, password });
   if (error) throw error;
-
-  // Fetch profile and store in localStorage for later use
-  const { data: profile, error: profileError } = await supabase
-    .from('users')
-    .select(`*, countries!users_country_id_fkey(slug) `)
-    .eq('id', data.user.id)
-    .maybeSingle();
-
-  if (profile && !profileError) {
-    localStorage.setItem('user', JSON.stringify(profile));
-  }
-
-  return { user: data.user, profile };
+  return data.user;
 }


### PR DESCRIPTION
## Summary
- enforce correct Supabase endpoints in documentation
- implement Supabase email/password login with visible errors and redirect
- require active Supabase session for Consultant dashboard and use proper sign-out

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6897bc1ea1608332b5022e8b8177a92c