### PR TITLE
Log Supabase URL during development

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,6 +4,12 @@ import App from './App.tsx'
 import './index.css'
 import { disableSWNav } from './lib/envRuntime'
 
+// Log Supabase URL in development for sanity-checking
+if (import.meta.env.DEV) {
+  const resolvedUrl = import.meta.env.VITE_SUPABASE_URL?.replace(/\/+$/, '')
+  console.info('🔗 VITE_SUPABASE_URL =', resolvedUrl)
+}
+
 // Safe Service Worker management
 if (typeof window !== 'undefined' && 'serviceWorker' in navigator) {
   if (disableSWNav) {


### PR DESCRIPTION
## Summary
- log VITE_SUPABASE_URL on startup in development for easy verification
- verified no lingering references to fwgaekupwecsruxjebbd.supabase.co

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6897c1d1715c8332beaaf21ec2eaaa86