### PR TITLE
Fix auth/profile wiring for consultant dashboard

### DIFF
--- a/src/components/ProtectedRoute.jsx
+++ b/src/components/ProtectedRoute.jsx
@@ -5,6 +5,7 @@ import { supabase } from '../lib/supabaseClient';
 const ProtectedRoute = ({ children, requiredRole }) => {
   const [loading, setLoading] = useState(true);
   const [userProfile, setUserProfile] = useState(null);
+  const [profileError, setProfileError] = useState(null);
 
   useEffect(() => {
     const checkSession = async () => {
@@ -25,11 +26,13 @@ const ProtectedRoute = ({ children, requiredRole }) => {
         const { data: profileData } = await supabase
           .from('users')
           .select('*')
-          .eq('id', user.id)
+          .eq('auth_user_id', user.id)
           .maybeSingle();
         if (profileData) {
           profile = profileData;
           localStorage.setItem('user', JSON.stringify(profileData));
+        } else {
+          setProfileError('Your profile was not found. Please contact an administrator.');
         }
       }
 
@@ -41,6 +44,12 @@ const ProtectedRoute = ({ children, requiredRole }) => {
   }, []);
 
   if (loading) return null;
+
+  if (profileError) {
+    return (
+      <div className="p-4 text-center text-red-500">{profileError}</div>
+    );
+  }
 
   if (!userProfile) {
     return <Navigate to="/login" replace />;

--- a/src/lib/supabaseClient.ts
+++ b/src/lib/supabaseClient.ts
@@ -5,8 +5,23 @@ const functionsUrl =
   import.meta.env.VITE_SUPABASE_FUNCTIONS_URL?.replace(/\/+$/, '') ||
   (baseUrl ? `${baseUrl}/functions/v1` : undefined);
 
+if (import.meta.env.DEV) {
+  console.log('Resolved Supabase URL:', baseUrl);
+}
+
+const options: any = {
+  auth: {
+    persistSession: true,
+    autoRefreshToken: true
+  }
+};
+
+if (functionsUrl) {
+  options.functions = { url: functionsUrl };
+}
+
 export const supabase = createClient(
   baseUrl!,
   import.meta.env.VITE_SUPABASE_ANON_KEY!,
-  functionsUrl ? { functions: { url: functionsUrl } } : undefined
+  options
 );

--- a/src/pages/ConsultantDashboard.tsx
+++ b/src/pages/ConsultantDashboard.tsx
@@ -41,6 +41,7 @@ const ConsultantDashboard: React.FC<ConsultantDashboardProps> = ({ country = 'gl
   const [showNotifications, setShowNotifications] = useState(false);
   const [showSettings, setShowSettings] = useState(false);
   const [sidebarOpen, setSidebarOpen] = useState(true);
+  const [profileError, setProfileError] = useState<string | null>(null);
   const { unreadCount } = useNotifications(consultant?.id || '');
 
   const slug = normalizeCountrySlug(country);
@@ -71,12 +72,17 @@ const ConsultantDashboard: React.FC<ConsultantDashboardProps> = ({ country = 'gl
               status
             )
           `)
-          .eq('id', user.id)
+          .eq('auth_user_id', user.id)
           .maybeSingle();
 
-        setConsultant(consultantData ?? null);
+        if (!consultantData) {
+          setProfileError('Your profile was not found. Please contact an administrator.');
+          return;
+        }
 
-        if (!consultantData || consultantData.role !== 'consultant') {
+        setConsultant(consultantData);
+
+        if (consultantData.role !== 'consultant') {
           navigate('/unauthorized');
           return;
         }
@@ -219,6 +225,14 @@ const ConsultantDashboard: React.FC<ConsultantDashboardProps> = ({ country = 'gl
           <div className="animate-spin rounded-full h-16 w-16 border-b-2 border-blue-600 mx-auto mb-4"></div>
           <p className="text-gray-600">Danışman panosu yükleniyor...</p>
         </div>
+      </div>
+    );
+  }
+
+  if (profileError) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-gray-50">
+        <p className="text-red-500">{profileError}</p>
       </div>
     );
   }

--- a/src/pages/dashboards/ConsultantDashboard.jsx
+++ b/src/pages/dashboards/ConsultantDashboard.jsx
@@ -55,6 +55,7 @@ const ConsultantDashboard = ({ country = 'global' }) => {
   const [documents, setDocuments] = useState([]);
   const [loading, setLoading] = useState(false);
   const [newMessage, setNewMessage] = useState('');
+  const [profileError, setProfileError] = useState(null);
 
   useEffect(() => {
     checkAuthAndLoadData();
@@ -82,14 +83,14 @@ const ConsultantDashboard = ({ country = 'global' }) => {
         return;
       }
 
-      const { data: profile, error } = await supabase
+      const { data: profile } = await supabase
         .from('users')
         .select(`*, countries!users_country_id_fkey(slug, name, flag_emoji)`)
-        .eq('id', user.id)
+        .eq('auth_user_id', user.id)
         .maybeSingle();
 
-      if (error || !profile) {
-        navigate('/login');
+      if (!profile) {
+        setProfileError('Your profile was not found. Please contact an administrator.');
         return;
       }
 
@@ -215,6 +216,12 @@ const ConsultantDashboard = ({ country = 'global' }) => {
     { title: 'Success Rate', value: '96%', change: '+2%', icon: TrendingUp, color: 'text-purple-600' },
     { title: 'Avg Rating', value: '4.9', change: '+0.1', icon: Award, color: 'text-orange-600' }
   ];
+
+  if (profileError) {
+    return (
+      <div className="p-4 text-center text-red-500">{profileError}</div>
+    );
+  }
 
   if (!consultant) {
     return (


### PR DESCRIPTION
## Summary
- fetch user profiles by `auth_user_id` instead of Supabase auth id
- persist Supabase auth session and log resolved Supabase URL in dev
- handle missing profile with user-facing message across dashboards and protected routes

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6897cba7ad80833297c73d7f42fc0f02