### PR TITLE
Fix client loading and login routing

### DIFF
--- a/src/lib/clientDataManager.ts
+++ b/src/lib/clientDataManager.ts
@@ -113,8 +113,11 @@ export class ClientDataManager {
         status
       `)
       .eq('consultant_id', consultantId)
-      .eq('service_country_id', params.countryId)
       .not('client_id', 'is', null);
+
+    if (params.countryId && params.countryId > 0) {
+      query = query.eq('service_country_id', params.countryId);
+    }
 
     if (params.search) {
       // Note: This is a simplified search, in production you'd want full-text search


### PR DESCRIPTION
## Summary
- route logins by user role after fetching user profile, storing profile, and seeding dev data
- centralize consultant client fetching with ClientDataManager and add refresh action to CountryBasedClients
- allow fetching all clients when no country filter is provided

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6897d6c57afc8332aee77010c0b14cfe