### PR TITLE
fix: use env vars for Supabase config

### DIFF
--- a/src/lib/supabaseClient.ts
+++ b/src/lib/supabaseClient.ts
@@ -1,14 +1,5 @@
 import { createClient } from '@supabase/supabase-js';
 
-const baseUrl = import.meta.env.VITE_SUPABASE_URL?.replace(/\/+$/, '');
-const functionsUrl =
-  import.meta.env.VITE_SUPABASE_FUNCTIONS_URL?.replace(/\/+$/, '') ||
-  (baseUrl ? `${baseUrl}/functions/v1` : undefined);
-
-if (import.meta.env.DEV) {
-  console.log('Resolved Supabase URL:', baseUrl);
-}
-
 const options: any = {
   auth: {
     persistSession: true,
@@ -16,12 +7,16 @@ const options: any = {
   }
 };
 
-if (functionsUrl) {
-  options.functions = { url: functionsUrl };
+if (import.meta.env.VITE_SUPABASE_FUNCTIONS_URL) {
+  options.functions = { url: import.meta.env.VITE_SUPABASE_FUNCTIONS_URL };
+}
+
+if (import.meta.env.DEV) {
+  console.log('Resolved Supabase URL:', import.meta.env.VITE_SUPABASE_URL);
 }
 
 export const supabase = createClient(
-  baseUrl!,
+  import.meta.env.VITE_SUPABASE_URL!,
   import.meta.env.VITE_SUPABASE_ANON_KEY!,
   options
 );


### PR DESCRIPTION
## Summary
- refactor Supabase client to read URL and anon key from environment

## Testing
- `npm run dev`
- `curl -s http://localhost:3001/src/lib/supabaseClient.ts | head -n 40`


------
https://chatgpt.com/codex/tasks/task_e_6899a428ac48833298a995cf2a8c5edc