### PR TITLE
Guard Supabase config and add healthcheck script

### DIFF
--- a/docs/env.md
+++ b/docs/env.md
@@ -5,7 +5,7 @@ Set these variables in both your local `.env` file and Netlify environment setti
 ```ini
 VITE_SUPABASE_URL=https://fwgaekupwecsruxjebb.supabase.co
 VITE_SUPABASE_FUNCTIONS_URL=https://fwgaekupwecsruxjebb.supabase.co/functions/v1
-VITE_SUPABASE_ANON_KEY=... (from the same project)
+VITE_SUPABASE_ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImZ3Z2Fla3Vwd2Vjc3J1eGplYmJkIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTM4OTQyNjEsImV4cCI6MjA2OTQ3MDI2MX0.HzssNASnDherzWBjEmoNtrsmqDRW03-bzSbN1w7xYEY
 ```
 
 `VITE_SUPABASE_FUNCTIONS_URL` is optional. If omitted, the app will default to `${VITE_SUPABASE_URL}/functions/v1`.

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "version": "1.0.0",
   "type": "module",
   "scripts": {
+    "predev": "ts-node scripts/healthcheck.ts",
+    "prebuild": "ts-node scripts/healthcheck.ts",
+    "hc": "ts-node scripts/healthcheck.ts",
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview"
@@ -25,6 +28,7 @@
     "postcss": "^8.4.35",
     "tailwindcss": "^3.4.1",
     "terser": "^5.43.1",
+    "ts-node": "^10.9.2",
     "typescript": "^5.5.3",
     "vite": "^5.4.2"
   }

--- a/scripts/healthcheck.ts
+++ b/scripts/healthcheck.ts
@@ -1,0 +1,39 @@
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+// rudimentary .env loader
+try {
+  const envFile = readFileSync(join(process.cwd(), '.env'), 'utf8');
+  for (const line of envFile.split(/\r?\n/)) {
+    const m = line.match(/^([^#=]+)=([^]*)$/);
+    if (m && !process.env[m[1]]) {
+      process.env[m[1]] = m[2];
+    }
+  }
+} catch {}
+
+const rawUrl = process.env.VITE_SUPABASE_URL || '';
+const baseUrl = rawUrl.replace(/\/+$/, '');
+
+if (!baseUrl) {
+  console.error('VITE_SUPABASE_URL is missing');
+  process.exit(1);
+}
+
+if (baseUrl.includes('jebbd')) {
+  console.error('Wrong Supabase project ref (contains "jebbd")');
+  process.exit(1);
+}
+
+try {
+  const res = await fetch(`${baseUrl}/rest/v1/`, { method: 'HEAD' });
+  if (res.ok) {
+    console.log('OK');
+  } else {
+    console.error('FAIL', res.status);
+    process.exit(1);
+  }
+} catch (err: any) {
+  console.error('FAIL', err.message);
+  process.exit(1);
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -33,10 +33,12 @@ import ConsultantDashboard from './pages/dashboards/ConsultantDashboard';
 import ClientDashboard from './pages/ClientDashboard';
 import MessagesPage from './pages/client/MessagesPage';
 import NewApplicationPage from './pages/client/NewApplicationPage';
+import DevSupabaseBanner from './components/shared/DevSupabaseBanner';
 
 function App() {
   return (
     <Router>
+      <DevSupabaseBanner />
       <div className="min-h-screen bg-white">
         <Routes>
           {/* Auth Routes (no header/footer) */}

--- a/src/components/shared/DevSupabaseBanner.tsx
+++ b/src/components/shared/DevSupabaseBanner.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+
+const DevSupabaseBanner: React.FC = () => {
+  if (!import.meta.env.DEV) return null;
+  const url = import.meta.env.VITE_SUPABASE_URL?.replace(/\/+$/, '');
+  if (!url) return null;
+  let host: string;
+  try {
+    host = new URL(url).host;
+  } catch {
+    host = url;
+  }
+  return (
+    <div className="fixed top-0 right-0 bg-black text-white text-xs px-2 py-1 z-50 opacity-70">
+      {host}
+    </div>
+  );
+};
+
+export default DevSupabaseBanner;

--- a/src/lib/supabaseClient.ts
+++ b/src/lib/supabaseClient.ts
@@ -11,9 +11,9 @@ const options: any = {
 if (functionsUrl) options.functions = { url: functionsUrl };
 
 if (import.meta.env.DEV) {
-  console.log('[SUPABASE] Resolved URL:', import.meta.env.VITE_SUPABASE_URL);
-  if (import.meta.env.VITE_SUPABASE_URL?.includes('fwgaekupwecsruxjebbd')) {
-    console.warn('[SUPABASE] Wrong project URL detected (ends with "d"). Fix your env.');
+  console.log('[SUPABASE] Resolved URL:', baseUrl);
+  if (baseUrl?.includes('fwgaekupwecsruxjebbd')) {
+    throw new Error("Wrong Supabase project ref (ends with 'd'). Fix VITE_SUPABASE_URL.");
   }
 }
 

--- a/src/pages/ConsultantDashboard.tsx
+++ b/src/pages/ConsultantDashboard.tsx
@@ -83,7 +83,11 @@ const ConsultantDashboard: React.FC<ConsultantDashboardProps> = ({ country = 'gl
         setConsultant(consultantData);
 
         if (consultantData.role !== 'consultant') {
-          navigate('/unauthorized');
+          if (consultantData.role === 'client') {
+            navigate('/client');
+          } else {
+            navigate('/unauthorized');
+          }
           return;
         }
 

--- a/src/pages/dashboards/ConsultantDashboard.jsx
+++ b/src/pages/dashboards/ConsultantDashboard.jsx
@@ -94,6 +94,15 @@ const ConsultantDashboard = ({ country = 'global' }) => {
         return;
       }
 
+      if (profile.role !== 'consultant') {
+        if (profile.role === 'client') {
+          navigate('/client');
+        } else {
+          navigate('/unauthorized');
+        }
+        return;
+      }
+
       setConsultant(profile);
       localStorage.setItem('user', JSON.stringify(profile));
       await loadConsultantData(profile.id);


### PR DESCRIPTION
## Summary
- centralize Supabase client creation with env-driven URLs and dev guard against the deprecated project ref
- show active Supabase host in a dev-only banner and redirect clients hitting consultant dashboards
- add healthcheck CLI and npm hooks to validate SUPABASE_URL before dev/build

## Testing
- `VITE_SUPABASE_URL=https://fwgaekupwecsruxjebb.supabase.co npm run hc` *(fails: ts-node: not found)*
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_6899adc8d3388332be3db477c46e9ce7