### PR TITLE
chore: switch to real Supabase project ref

### DIFF
--- a/docs/env.md
+++ b/docs/env.md
@@ -3,8 +3,8 @@
 Set these variables in both your local `.env` file and Netlify environment settings.
 
 ```ini
-VITE_SUPABASE_URL=https://fwgaekupwecsruxjebb.supabase.co
-VITE_SUPABASE_FUNCTIONS_URL=https://fwgaekupwecsruxjebb.supabase.co/functions/v1
+VITE_SUPABASE_URL=https://fwgaekupwecsruxjebbd.supabase.co
+VITE_SUPABASE_FUNCTIONS_URL=https://fwgaekupwecsruxjebbd.supabase.co/functions/v1
 VITE_SUPABASE_ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImZ3Z2Fla3Vwd2Vjc3J1eGplYmJkIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTM4OTQyNjEsImV4cCI6MjA2OTQ3MDI2MX0.HzssNASnDherzWBjEmoNtrsmqDRW03-bzSbN1w7xYEY
 ```
 

--- a/scripts/healthcheck.ts
+++ b/scripts/healthcheck.ts
@@ -22,7 +22,7 @@ if (!baseUrl) {
 let host = '';
 try { host = new URL(baseUrl).host; } catch { host = baseUrl.replace(/^https?:\/\//,''); }
 const projectRef = host.split('.')[0];
-const EXPECTED_REF = 'fwgaekupwecsruxjebb';
+const EXPECTED_REF = 'fwgaekupwecsruxjebbd';
 
 if (!projectRef) { console.error('Cannot resolve Supabase project ref from VITE_SUPABASE_URL'); process.exit(1); }
 if (projectRef !== EXPECTED_REF) {
@@ -33,7 +33,7 @@ if (projectRef !== EXPECTED_REF) {
 // anon key presence (public)
 if (!anon) { console.error('VITE_SUPABASE_ANON_KEY is missing'); process.exit(1); }
 
-// CI/Netlify'da network check ATLA
+// CI/Netlify'da network check ATLA (kalıyor)
 const isCI = !!process.env.CI || !!process.env.NETLIFY;
 const STRICT = process.env.HEALTHCHECK_STRICT === 'true' && !isCI;
 

--- a/src/lib/supabaseClient.ts
+++ b/src/lib/supabaseClient.ts
@@ -12,13 +12,17 @@ if (functionsUrl) options.functions = { url: functionsUrl };
 
 if (import.meta.env.DEV) {
   console.log('[SUPABASE] Resolved URL:', baseUrl);
-  if (baseUrl?.includes('fwgaekupwecsruxjebbd')) {
-    throw new Error("Wrong Supabase project ref (ends with 'd'). Fix VITE_SUPABASE_URL.");
-  }
-  console.log('[SUPABASE] Resolved URL:', baseUrl);
-  if (baseUrl?.includes('fwgaekupwecsruxjebbd')) {
-    throw new Error("Wrong Supabase project ref (ends with 'd'). Fix VITE_SUPABASE_URL.");
-  }
+
+  // Exact match doğrulaması (opsiyonel): yanlış ref'leri erken yakala
+  try {
+    const host = new URL(baseUrl!).host;
+    const ref = host.split('.')[0];
+    const EXPECTED_REF = 'fwgaekupwecsruxjebbd';
+    if (ref !== EXPECTED_REF) {
+      // Dev-only uyarı; prod'u kırma
+      console.warn(`[SUPABASE] Project ref mismatch (dev): expected="${EXPECTED_REF}" actual="${ref}"`);
+    }
+  } catch {}
 }
 
 export const supabase = createClient(


### PR DESCRIPTION
## Summary
- use actual Supabase project ref `fwgaekupwecsruxjebbd`
- keep CI healthcheck on ref/format only
- warn in dev if Supabase ref mismatches

## Testing
- `VITE_SUPABASE_URL=https://fwgaekupwecsruxjebbd.supabase.co VITE_SUPABASE_ANON_KEY=… npm run hc`

------
https://chatgpt.com/codex/tasks/task_e_6899c804e0d48332b15fbdbc971e8663