### PR TITLE
feat: add profile sync and client guard

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
+import { BrowserRouter as Router, Routes, Route, Navigate } from 'react-router-dom';
 
 // Layout Components
 import Header from './components/Header';
@@ -68,7 +68,7 @@ function App() {
           <Route path="/consultant-dashboard/*" element={<ConsultantDashboard country="global" />} />
           <Route path="/client" element={<RequireClient><ClientDashboard /></RequireClient>} />
           <Route path="/client/*" element={<RequireClient><ClientDashboard /></RequireClient>} />
-          
+
           {/* Public Routes (with header and footer) - Catch-all for other routes */}
           <Route path="/*" element={
             <div>
@@ -102,6 +102,7 @@ function App() {
               <Footer />
             </div>
           } />
+          <Route path="*" element={<Navigate to="/login" replace />} />
         </Routes>
       </div>
     </Router>

--- a/src/lib/ensureProfile.ts
+++ b/src/lib/ensureProfile.ts
@@ -1,0 +1,33 @@
+import { supabase } from '@/lib/supabaseClient';
+
+export async function ensureProfile() {
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) throw new Error('No session');
+
+  // 1) dene: var mı?
+  let { data: profile, error } = await supabase
+    .from('users')
+    .select('auth_user_id, role, first_name, email')
+    .eq('auth_user_id', user.id)
+    .maybeSingle();
+
+  // 2) yoksa oluştur
+  if (!profile) {
+    const ins = await supabase
+      .from('users')
+      .insert({
+        auth_user_id: user.id,
+        email: user.email,
+        role: 'client',
+        first_name: user.email?.split('@')[0] ?? 'Client'
+      })
+      .select()
+      .single();
+    if (ins.error) throw ins.error;
+    profile = ins.data!;
+  }
+
+  try { localStorage.setItem('user', JSON.stringify(profile)); } catch {}
+  return profile;
+}
+

--- a/src/lib/supabaseClient.ts
+++ b/src/lib/supabaseClient.ts
@@ -5,12 +5,12 @@ const functionsUrl =
   import.meta.env.VITE_SUPABASE_FUNCTIONS_URL?.replace(/\/+$/, '') ||
   (baseUrl ? `${baseUrl}/functions/v1` : undefined);
 
-const options: any = { auth: { persistSession: true, autoRefreshToken: true } };
-if (functionsUrl) options.functions = { url: functionsUrl };
-
 if (!baseUrl || !import.meta.env.VITE_SUPABASE_ANON_KEY) {
   throw new Error('Supabase env missing: set VITE_SUPABASE_URL and VITE_SUPABASE_ANON_KEY');
 }
+
+const options: any = { auth: { persistSession: true, autoRefreshToken: true } };
+if (functionsUrl) options.functions = { url: functionsUrl };
 
 if (import.meta.env.DEV) {
   try {

--- a/src/routes/RequireClient.tsx
+++ b/src/routes/RequireClient.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { supabase } from '@/lib/supabaseClient';
+import { ensureProfile } from '@/lib/ensureProfile';
 
 export default function RequireClient({ children }: { children: React.ReactNode }) {
   const [ready, setReady] = useState(false);
@@ -11,20 +12,13 @@ export default function RequireClient({ children }: { children: React.ReactNode 
       const { data: { user } } = await supabase.auth.getUser();
       if (!user) return nav('/login', { replace: true });
 
-      const { data: p, error } = await supabase
-        .from('users')
-        .select('role,auth_user_id')
-        .eq('auth_user_id', user.id)
-        .maybeSingle();
-
-      if (error || !p) return nav('/login', { replace: true });
+      const p = await ensureProfile();
       if (p.role !== 'client') return nav('/unauthorized', { replace: true });
 
-      try { localStorage.setItem('user', JSON.stringify(p)); } catch {}
       setReady(true);
     })();
   }, [nav]);
 
-  if (!ready) return null; // istersen skeleton/spinner ekleyebilirsin
+  if (!ready) return null; // dilersen skeleton ekleyebilirsin
   return <>{children}</>;
 }

--- a/supabase/migrations/2025-08-11_users_profile_and_policies.sql
+++ b/supabase/migrations/2025-08-11_users_profile_and_policies.sql
@@ -1,24 +1,24 @@
--- column
+-- 1) auth_user_id kolonu
 alter table public.users add column if not exists auth_user_id uuid;
 
--- backfill (email → auth.users.id)
+-- 2) var olan kayıtları e-postadan backfill
 update public.users u
 set auth_user_id = a.id
 from auth.users a
 where u.email = a.email
   and u.auth_user_id is null;
 
--- unique index
+-- 3) unique index (idempotent)
 create unique index if not exists users_auth_user_id_uq_idx
   on public.users(auth_user_id);
 
--- FK
+-- 4) foreign key
 alter table public.users
   drop constraint if exists users_auth_user_id_fkey,
   add constraint users_auth_user_id_fkey
     foreign key (auth_user_id) references auth.users(id) on delete cascade;
 
--- RLS
+-- 5) RLS + policy'ler
 alter table public.users enable row level security;
 
 drop policy if exists users_select_own on public.users;
@@ -36,5 +36,21 @@ create policy users_update_own
 on public.users for update
 using (auth.uid() = auth_user_id);
 
--- privileges
+-- 6) authenticated rolü için izinler
 grant select, insert, update on public.users to authenticated;
+
+-- 7) AUTH → PROFILE: signup'ta otomatik profil
+create or replace function public.handle_auth_user_created()
+returns trigger language plpgsql security definer as $$
+begin
+  insert into public.users (auth_user_id, email, role, first_name)
+  values (new.id, new.email, 'client', split_part(coalesce(new.email,''),'@',1))
+  on conflict (auth_user_id) do nothing;
+  return new;
+end; $$;
+
+drop trigger if exists on_auth_user_created on auth.users;
+create trigger on_auth_user_created
+after insert on auth.users
+for each row execute procedure public.handle_auth_user_created();
+


### PR DESCRIPTION
## Summary
- ensure users table stays linked to auth.users and auto-create profiles on signup
- add Supabase client helper and EnsureProfile util for consistent session handling
- gate /client routes and login redirects based on role

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6899e197673483328bafe0c79631438d